### PR TITLE
Add note about runtimes and threads to the docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,11 @@ impl ContextBuilder {
 
 /// Context is a wrapper around a QuickJS Javascript context.
 /// It is the primary way to interact with the runtime.
+///
+/// For each `Context` instance a new instance of QuickJS
+/// runtime is created. It means that it is safe to use
+/// different contexts in different threads, but each
+/// `Context` instance shuld be used only from a single thread.
 pub struct Context {
     wrapper: bindings::ContextWrapper,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ impl ContextBuilder {
 /// For each `Context` instance a new instance of QuickJS
 /// runtime is created. It means that it is safe to use
 /// different contexts in different threads, but each
-/// `Context` instance shuld be used only from a single thread.
+/// `Context` instance must be used only from a single thread.
 pub struct Context {
     wrapper: bindings::ContextWrapper,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,9 @@ impl ContextBuilder {
 /// It is the primary way to interact with the runtime.
 ///
 /// For each `Context` instance a new instance of QuickJS
-/// runtime is created.
+/// runtime is created. It means that it is safe to use
+/// different contexts in different threads, but each
+/// `Context` instance shuld be used only from a single thread.
 pub struct Context {
     wrapper: bindings::ContextWrapper,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,9 +143,7 @@ impl ContextBuilder {
 /// It is the primary way to interact with the runtime.
 ///
 /// For each `Context` instance a new instance of QuickJS
-/// runtime is created. It means that it is safe to use
-/// different contexts in different threads, but each
-/// `Context` instance shuld be used only from a single thread.
+/// runtime is created.
 pub struct Context {
     wrapper: bindings::ContextWrapper,
 }


### PR DESCRIPTION
This PR adds a note about the fact that a new JS runtime is created for each `Context` instance.