### PR TITLE
Fix signed to unsigned conversion in QuickJS stack overflow check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,36 @@
 version: 2.0
+
+shared: &shared
+  docker:
+    - image: debian
+  steps:
+    - checkout
+    - run:
+        name: Setup, Build & Test
+        command: |
+          export PATH="$HOME/.cargo/bin:$HOME:$PATH"
+
+          apt-get update && apt-get install -y curl
+
+          echo "Installing Rust..."
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+          echo "Installing just..."
+          curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git casey/just --target x86_64-unknown-linux-musl --to $HOME
+          hash -r
+          just FEATURES="$FEATURES" ci-debian
+
 jobs:
+  default:
+    environment:
+      FEATURES: ''
+    <<: *shared
+  patched:
+    environment:
+      FEATURES: 'patched'
+    <<: *shared
+
+workflows:
+  version: 2
   build:
-    docker:
-      - image: debian
-    steps:
-      - checkout
-      - run:
-          name: Setup, Build & Test
-          command: |
-            export PATH="$HOME/.cargo/bin:$HOME:$PATH"
-
-            apt-get update && apt-get install -y curl
-
-            echo "Installing Rust..."
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-            echo "Installing just..."
-            curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git casey/just --target x86_64-unknown-linux-musl --to $HOME
-            hash -r
-            just ci-debian
+    - default
+    - patched

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,36 +1,47 @@
-version: 2.0
+version: 2.1
 
-shared: &shared
-  docker:
-    - image: debian
-  steps:
-    - checkout
-    - run:
-        name: Setup, Build & Test
-        command: |
-          export PATH="$HOME/.cargo/bin:$HOME:$PATH"
+commands:
+  tests:
+    description: "Run tests"
+    parameters:
+      features:
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Setup
+          command: |
+            echo "Installing curl..."
+            apt-get update && apt-get install -y curl
+            echo "Installing Rust..."
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+            echo "Installing just..."
+            curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git casey/just --target x86_64-unknown-linux-musl --to $HOME
+      - run: 
+          name: Test
+          command: |
+            export PATH="$HOME/.cargo/bin:$HOME:$PATH"
+            just FEATURES="<<parameters.features>>" ci-debian
 
-          apt-get update && apt-get install -y curl
-
-          echo "Installing Rust..."
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-          echo "Installing just..."
-          curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git casey/just --target x86_64-unknown-linux-musl --to $HOME
-          hash -r
-          just FEATURES="$FEATURES" ci-debian
 
 jobs:
-  default:
-    environment:
-      FEATURES: ''
-    <<: *shared
-  patched:
-    environment:
-      FEATURES: 'patched'
-    <<: *shared
+  test-features-default:
+    docker:
+      - image: debian
+    steps:
+      - tests:
+          features: ""
+  test-features-patched:
+    docker:
+      - image: debian
+    steps:
+      - tests:
+          features: "patched"
 
 workflows:
   version: 2
-  build:
-    - default
-    - patched
+  tests:
+    jobs:
+      - test-features-default
+      - test-features-patched
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ libquickjs-sys = { version = "0.3.0", path = "./libquickjs-sys" }
 members = [
     "libquickjs-sys",
 ]
+
+[features]
+patched = ["libquickjs-sys/patched"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ If you would like to use a system version instead, see below.
 
 QuickJS will always be statically linked to your binary.
 
+### Features
+
+The crate supports the following features:
+
+* `patched` applies QuickJS patches that can be found in `libquickjs-sys/embed/patches` directory.
+
 ### System installation
 
 To use the system installation, without the bundled feature, first install the required 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,12 @@ jobs:
       
   - job: macos_stable
     displayName: Mac OS Stable
+    strategy:
+      matrix:
+        default:
+          FEATURES: ''
+        patched:
+          FEATURES: 'patched'
 
     pool:
       vmImage: 'macOS-10.14'
@@ -37,5 +43,5 @@ jobs:
           echo "Installing just..."
           curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git casey/just --to $HOME
           hash -r
-          just ci-macos
+          just FEATURES="$FEATURES" ci-macos
         displayName: setup and test

--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 embed_dir := "./libquickjs-sys/embed/quickjs"
 
 DOWNLOAD_URL := "https://bellard.org/quickjs/quickjs-2019-08-10.tar.xz"
+FEATURES := ""
 
 download-new:
     test -d {{embed_dir}} && rm -r {{embed_dir}} || echo ""
@@ -25,7 +26,7 @@ ci-debian-setup:
 
 ci-test:
     # Limit test threads to 1 to show test name before execution.
-    RUST_TEST_THREADS=1 cargo test --verbose
+    RUST_TEST_THREADS=1 cargo test --verbose --features="{{FEATURES}}"
 
 ci-lint:
     rustup component add rustfmt clippy

--- a/libquickjs-sys/Cargo.toml
+++ b/libquickjs-sys/Cargo.toml
@@ -20,6 +20,7 @@ copy_dir = { version = "0.1.2", optional = true }
 
 [features]
 bundled = ["copy_dir"]
+patched = []
 default = ["bundled"]
 
 system = ["bindgen"]

--- a/libquickjs-sys/embed/patches/stack-overflow-signed.patch
+++ b/libquickjs-sys/embed/patches/stack-overflow-signed.patch
@@ -1,0 +1,15 @@
+diff -urN quickjs-2019-07-28/quickjs.c quickjs-2019-07-28-stack-overflow-signed/quickjs.c
+--- quickjs-2019-07-28/quickjs.c	2019-07-28 15:03:03.000000000 +0000
++++ quickjs-2019-07-28-stack-overflow-signed/quickjs.c	2019-08-09 20:00:03.666846091 +0000
+@@ -1732,9 +1732,9 @@
+ 
+ static inline BOOL js_check_stack_overflow(JSContext *ctx, size_t alloca_size)
+ {
+-    size_t size;
++    ptrdiff_t size;
+     size = ctx->stack_top - js_get_stack_pointer();
+-    return unlikely((size + alloca_size) > ctx->stack_size);
++    return unlikely((size + (ptrdiff_t)alloca_size) > (ptrdiff_t)ctx->stack_size);
+ }
+ #endif
+ 


### PR DESCRIPTION
Hi!

Sometimes QuickJS gives `stack overflow` exception when it shouldn't because of signed to unsigned conversion in the code that checks stack usage. I've [sent the patch to QuickJS mailing list](https://www.freelists.org/post/quickjs-devel/Stack-overflow-exception-caused-by-signed-to-unsigned-integer-conversion), but it would be nice to have this merged (and maybe even published) before the next QuickJS release.