### PR TITLE
Free resources allocated in `deserialize_object` function

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ update-quickjs: download-new generate-bindings download-cleanup
 
 ci-debian-setup:
     echo "Installing dependencies..."
-    apt update && apt-get install -y curl xz-utils build-essential gcc-multilib libclang-dev clang
+    apt update && apt-get install -y curl xz-utils build-essential gcc-multilib libclang-dev clang valgrind
 
 ci-test:
     # Limit test threads to 1 to show test name before execution.
@@ -37,7 +37,11 @@ ci-lint:
     echo "Checking clippy..."
     cargo clippy
 
-ci-debian: ci-debian-setup ci-test ci-lint
+ci-valgrind:
+    echo "Checking for memory leaks..."
+    find target/debug -maxdepth 1 -type f -executable | xargs valgrind --leak-check=full --error-exitcode=1
+
+ci-debian: ci-debian-setup ci-test ci-lint ci-valgrind
 
 ci-macos-setup:
     echo "setup"

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -262,6 +262,7 @@ fn deserialize_object(context: *mut q::JSContext, obj: &q::JSValue) -> Result<Js
         ));
     }
 
+    // TODO: refactor into a more Rust-idiomatic iterator wrapper.
     let properties = DroppableValue::new(properties, |&mut properties| {
         for index in 0..count {
             let prop = unsafe { properties.offset(index as isize) };

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -292,6 +292,17 @@ fn deserialize_object(context: *mut q::JSContext, obj: &q::JSValue) -> Result<Js
         };
         map.insert(key, value);
     }
+
+    for index in 0..count {
+        let prop = unsafe { properties.offset(index as isize) };
+        unsafe {
+            q::JS_FreeAtom(context, (*prop).atom);
+        }
+    }
+    unsafe {
+        q::js_free(context, properties as *mut std::ffi::c_void);
+    }
+
     Ok(JsValue::Object(map))
 }
 

--- a/src/droppable_value.rs
+++ b/src/droppable_value.rs
@@ -1,0 +1,47 @@
+/// A small wrapper that frees resources that have to be freed
+/// automatically when they go out of scope.
+pub struct DroppableValue<T, F>
+where
+    F: FnMut(&mut T),
+{
+    value: T,
+    drop_fn: F,
+}
+
+impl<T, F> DroppableValue<T, F>
+where
+    F: FnMut(&mut T),
+{
+    pub fn new(value: T, drop_fn: F) -> Self {
+        Self { value, drop_fn }
+    }
+}
+
+impl<T, F> Drop for DroppableValue<T, F>
+where
+    F: FnMut(&mut T),
+{
+    fn drop(&mut self) {
+        (self.drop_fn)(&mut self.value);
+    }
+}
+
+impl<T, F> std::ops::Deref for DroppableValue<T, F>
+where
+    F: FnMut(&mut T),
+{
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.value
+    }
+}
+
+impl<T, F> std::ops::DerefMut for DroppableValue<T, F>
+where
+    F: FnMut(&mut T),
+{
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 
 mod bindings;
 mod callback;
+mod droppable_value;
 mod value;
 
 use std::{convert::TryFrom, error, fmt};


### PR DESCRIPTION
Closes #36 

Freeing value is implemented using a special RAII-style wrapper, which owns a pointer and a function that frees this pointer. That function is invoked when the wrapper goes out of scope, which guarantees that the pointer is freed even in case of returning of the error without additional complication of the code. I feel that this can be also reused in other parts of the code where resources should be freed and there are possible errors, but I haven't investigated in what other places can it be used because I would like to hear you feedback about it first.

The fix was validated using Valgrind:

## Before
```
$ valgrind --leak-check=full ./target/debug/quick_js-046c447bbed8033c
==5162== Memcheck, a memory error detector
==5162== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==5162== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==5162== Command: ./target/debug/quick_js-046c447bbed8033c
==5162== 

running 13 tests
test tests::call_async ... ok
test tests::test_callback_argn_variants ... ok
test tests::test_call_large_string ... ok
test tests::memory_limit_exceeded ... ok
test tests::context_reset ... ok
test tests::test_eval_syntax_error ... ok
test tests::test_callback_invalid_argcount ... ok
test tests::moved_context ... ok
test tests::eval_async ... ok
test tests::test_call ... ok
test tests::test_eval_exception ... ok
test tests::test_callback ... ok
test tests::test_eval_pass ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

==5162== 
==5162== HEAP SUMMARY:
==5162==     in use at exit: 40 bytes in 3 blocks
==5162==   total heap usage: 18,422 allocs, 18,419 frees, 1,934,505 bytes allocated
==5162== 
==5162== 8 bytes in 1 blocks are definitely lost in loss record 1 of 2
==5162==    at 0x483874F: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==5162==    by 0x1E2E82: js_def_malloc (quickjs.c:1354)
==5162==    by 0x1F6D8C: js_malloc_rt (quickjs.c:1075)
==5162==    by 0x1F6D8C: js_malloc (quickjs.c:1115)
==5162==    by 0x223F4B: JS_GetOwnPropertyNamesInternal (quickjs.c:6935)
==5162==    by 0x138054: quick_js::bindings::deserialize_object (bindings.rs:255)
==5162==    by 0x139491: quick_js::bindings::deserialize_value (bindings.rs:396)
==5162==    by 0x1383C2: quick_js::bindings::deserialize_object (bindings.rs:270)
==5162==    by 0x139491: quick_js::bindings::deserialize_value (bindings.rs:396)
==5162==    by 0x13BA87: quick_js::bindings::ContextWrapper::to_value (bindings.rs:714)
==5162==    by 0x139F09: quick_js::bindings::OwnedValueRef::to_value (bindings.rs:543)
==5162==    by 0x123707: quick_js::Context::eval (lib.rs:215)
==5162==    by 0x16A629: quick_js::tests::test_eval_pass (lib.rs:411)
==5162== 
==5162== 32 bytes in 2 blocks are definitely lost in loss record 2 of 2
==5162==    at 0x483874F: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==5162==    by 0x1E2E82: js_def_malloc (quickjs.c:1354)
==5162==    by 0x1F6D8C: js_malloc_rt (quickjs.c:1075)
==5162==    by 0x1F6D8C: js_malloc (quickjs.c:1115)
==5162==    by 0x223F4B: JS_GetOwnPropertyNamesInternal (quickjs.c:6935)
==5162==    by 0x138054: quick_js::bindings::deserialize_object (bindings.rs:255)
==5162==    by 0x139491: quick_js::bindings::deserialize_value (bindings.rs:396)
==5162==    by 0x13BA87: quick_js::bindings::ContextWrapper::to_value (bindings.rs:714)
==5162==    by 0x139F09: quick_js::bindings::OwnedValueRef::to_value (bindings.rs:543)
==5162==    by 0x123707: quick_js::Context::eval (lib.rs:215)
==5162==    by 0x16A629: quick_js::tests::test_eval_pass (lib.rs:411)
==5162==    by 0x12BE59: quick_js::tests::test_eval_pass::{{closure}} (lib.rs:357)
==5162==    by 0x159C9D: core::ops::function::FnOnce::call_once (function.rs:231)
==5162== 
==5162== LEAK SUMMARY:
==5162==    definitely lost: 40 bytes in 3 blocks
==5162==    indirectly lost: 0 bytes in 0 blocks
==5162==      possibly lost: 0 bytes in 0 blocks
==5162==    still reachable: 0 bytes in 0 blocks
==5162==         suppressed: 0 bytes in 0 blocks
==5162== 
==5162== For counts of detected and suppressed errors, rerun with: -v
==5162== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

## After
```
$ valgrind --leak-check=full ./target/debug/quick_js-046c447bbed8033c 
==16254== Memcheck, a memory error detector
==16254== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==16254== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==16254== Command: ./target/debug/quick_js-046c447bbed8033c
==16254== 

running 13 tests
test tests::call_async ... ok
test tests::test_callback_argn_variants ... ok
test tests::test_eval_syntax_error ... ok
test tests::moved_context ... ok
test tests::test_eval_pass ... ok
test tests::context_reset ... ok
test tests::test_callback_invalid_argcount ... ok
test tests::eval_async ... ok
test tests::test_eval_exception ... ok
test tests::test_call_large_string ... ok
test tests::test_call ... ok
test tests::memory_limit_exceeded ... ok
test tests::test_callback ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

==16254== 
==16254== HEAP SUMMARY:
==16254==     in use at exit: 0 bytes in 0 blocks
==16254==   total heap usage: 18,421 allocs, 18,421 frees, 1,934,473 bytes allocated
==16254== 
==16254== All heap blocks were freed -- no leaks are possible
==16254== 
==16254== For counts of detected and suppressed errors, rerun with: -v
==16254== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

I've also added Valgrind to CI, so the build should be failing in case of memory leaks in the tests.