### PR TITLE
Free runtime if context cannot be created

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -691,6 +691,9 @@ impl ContextWrapper {
 
         let context = unsafe { q::JS_NewContext(runtime) };
         if context.is_null() {
+            unsafe {
+                q::JS_FreeRuntime(runtime);
+            }
             return Err(ContextError::ContextCreationFailed);
         }
 


### PR DESCRIPTION
This is a fix of a leak occurring when runtime is created, but context cannot be created.