### PR TITLE
chore: Deny warnings only for tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,7 @@
 //! "#).unwrap();
 //! ```
 
-#![deny(warnings)]
-#![deny(missing_docs)]
+#![cfg_attr(test, deny(warnings, missing_docs))]
 
 mod bindings;
 mod callback;


### PR DESCRIPTION
Closes #44

It turns out that just putting `#![deny(warnings)]` behind `#[cfg(test)]` is not possible, it gives an error:

```
   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them,
and are usually found at the beginning of source files. Outer attributes, like
`#[test]`, annotate the item following them.
```
So I did it using `RUSTFLAGS` in `justfile` instead. The result should be the same, although not exactly, because dependencies with warnings won't compile now. Luckily, it is not an issue now.