### PR TITLE
fix: Use space instead of comma as a separator

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -125,7 +125,7 @@ mod log {
                 .into_iter()
                 .map(print_value)
                 .collect::<Vec<_>>()
-                .join(", ");
+                .join(" ");
 
             log::log!(log_level, "{}", msg);
         }


### PR DESCRIPTION
Although WhatWG living standard doesn't strictly require it, it says the following about the separators between objects printed using `console.log`:

> How the implementation prints args is up to the implementation, but implementations should separate the objects by a space or something similar, as that has become a developer expectation.

Major browsers and Node.js use space as a separator too, so that

```js
let name = // ...
console.log('hello', name)
```

prints what one would expect.