### PR TITLE
libquickjs-sys: use cc to determine the proper compiler

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
         echo "Install just"
         curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git casey/just --target x86_64-unknown-linux-musl --to $HOME
         echo "Run setup"
+        sudo apt-get update -y
         sudo apt-get install -y curl xz-utils build-essential gcc-multilib valgrind
       if: matrix.os == 'ubuntu-latest'
 

--- a/libquickjs-sys/Cargo.toml
+++ b/libquickjs-sys/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["quickjs"]
 build = "build.rs"
 
 [features]
-bundled = ["copy_dir"]
+bundled = ["cc", "copy_dir"]
 patched = []
 default = ["bundled"]
 
@@ -22,5 +22,6 @@ system = ["bindgen"]
 
 [build-dependencies]
 bindgen = { version = "0.51.0", optional = true }
+cc = { version = "1.0", optional = true }
 copy_dir = { version = "0.1.2", optional = true }
 

--- a/libquickjs-sys/build.rs
+++ b/libquickjs-sys/build.rs
@@ -67,8 +67,10 @@ fn main() {
     apply_patches(&code_dir);
 
     eprintln!("Compiling quickjs...");
+    let compiler = cc::Build::new().get_compiler();
     std::process::Command::new("make")
         .arg(format!("lib{}.a", LIB_NAME))
+        .arg(format!("CC={}", compiler.path().to_string_lossy()))
         .current_dir(&code_dir)
         .spawn()
         .expect("Could not compile quickjs")


### PR DESCRIPTION
This allows us to build quickjs for the following targets:
* `x86_64-unknown-linux-musl`
* `x86_64-pc-windows-gnu` (through cross-compilation)