### PR TITLE
Support JsValue in Callbacks + Prevent Double Free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## v0.4.1 - 2021-03-15
 
-* Fixed use after free in `set_global` (https://github.com/theduke/quickjs-rs/issues/105)
+* Fixed use after free in `set_global` [#105](https://github.com/theduke/quickjs-rs/issues/105)
+* `add_callback` can now take `JsValue` arguments [#109](https://github.com/theduke/quickjs-rs/issues/109)
 
 ## v0.4.0 - 2021-02-05
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -275,6 +275,9 @@ fn call_async() {
 fn test_callback() {
     let c = Context::new().unwrap();
 
+    c.add_callback("no_arguments", || true).unwrap();
+    assert_eq!(c.eval_as::<bool>("no_arguments()").unwrap(), true);
+
     c.add_callback("cb1", |flag: bool| !flag).unwrap();
     assert_eq!(c.eval("cb1(true)").unwrap(), JsValue::Bool(false),);
 
@@ -292,6 +295,13 @@ fn test_callback() {
     c.add_callback("sum", |items: Vec<i32>| -> i32 { items.iter().sum() })
         .unwrap();
     assert_eq!(c.eval("sum([1, 2, 3, 4, 5, 6])").unwrap(), JsValue::Int(21),);
+
+    c.add_callback("identity", |value: JsValue| -> JsValue { value })
+        .unwrap();
+    {
+        let v = JsValue::from(22);
+        assert_eq!(c.eval("identity(22)").unwrap(), v);
+    }
 }
 
 #[test]


### PR DESCRIPTION
- Allow JsValue arguments in `add_callback` + dead code cleanup
- Prevent double free on set_property failure

Closes #109
Closes #107
