### PR TITLE
Added support for returning undefined in async functions

### DIFF
--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -572,7 +572,15 @@ impl ContextWrapper {
                     let res_val = global.property_require("__promiseResult")?;
                     if res_val.is_bool() {
                         let ok = res_val.to_bool()?;
-                        let value = global.property_require("__promiseValue")?;
+                        let value = global.property("__promiseValue")?.unwrap_or_else(|| {
+                            OwnedJsValue::new(
+                                self,
+                                q::JSValue {
+                                    u: q::JSValueUnion { int32: 0 },
+                                    tag: TAG_UNDEFINED,
+                                },
+                            )
+                        });
 
                         if ok {
                             return self.resolve_value(value);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -622,3 +622,9 @@ fn test_global_setter() {
     ctx.set_global("a", "a").unwrap();
     ctx.eval("a + 1").unwrap();
 }
+
+#[test]
+fn test_async_fn_returning_undefined() {
+    let ctx = Context::new().unwrap();
+    ctx.eval("(async () => undefined)()").unwrap();
+}


### PR DESCRIPTION
Currently quickjs-rs is not able to handle async functions that return undefined. Functions like `async () => { }` or `async () => undefined` will throw the following error:

```
failures:

---- tests::test_async_fn_returning_undefined stdout ----
thread 'tests::test_async_fn_returning_undefined' panicked at 'called `Result::unwrap()` on an `Err` value: Internal("Property '__promiseValue' not found")', src/tests.rs:629:43
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR allows `__promiseValue` to be undefined when `__promiseResult === true`