### PR TITLE
Add interrupt handler callback support

### DIFF
--- a/src/bindings/compile.rs
+++ b/src/bindings/compile.rs
@@ -28,7 +28,7 @@ pub fn compile<'a>(
     };
 
     // check for error
-    context.ensure_no_excpetion()?;
+    context.ensure_no_exception()?;
     Ok(value)
 }
 
@@ -45,7 +45,7 @@ pub fn run_compiled_function<'a>(
         OwnedJsValue::new(context, v)
     };
 
-    context.ensure_no_excpetion().map_err(|e| {
+    context.ensure_no_exception().map_err(|e| {
         if let ExecutionError::Internal(msg) = e {
             ExecutionError::Internal(format!("Could not evaluate compiled function: {}", msg))
         } else {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -622,3 +622,17 @@ fn test_global_setter() {
     ctx.set_global("a", "a").unwrap();
     ctx.eval("a + 1").unwrap();
 }
+
+// test interrupt handler, ensuring that closure data works
+#[test]
+fn test_interrupt_handler() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let ctx = Context::new().unwrap();
+    let arg = AtomicUsize::new(0);
+    ctx.set_interrupt_handler(move || {
+        let counter = arg.fetch_add(1, Ordering::Relaxed);
+        println!("{}", counter);
+        counter == 10
+    });
+    assert_eq!(ctx.eval("while (1) {}"), Err(ExecutionError::Exception(JsValue::String("InternalError: interrupted".to_string()))));
+}


### PR DESCRIPTION
QuickJS supports an "interrupt handler" to allow JS execution to be stopped in case of e.g. Ctrl+C or timeouts. I've added support for it to the API. The type constraints on it are probably stricter than they need to be but this was sufficient for my purposes.